### PR TITLE
Prevent Sortable from Being Created Multiple Times

### DIFF
--- a/script.js
+++ b/script.js
@@ -245,6 +245,9 @@ function openMainSettings() {
       schemeInput.classList.add("open");
   });
 }
+
+let sortableCreated = false;
+
 function openPtSettings() {
   // make settings visible, prevent scrolling
   settingsOverlay.classList.add("visible");
@@ -293,7 +296,7 @@ function openPtSettings() {
     Sortable.create(container, {
       animation: 150,
     });
-    window.sortableCreated = true;
+    sortableCreated = true;
   }
   loadOrder();
 }

--- a/script.js
+++ b/script.js
@@ -289,10 +289,12 @@ function openPtSettings() {
       handleDoubleClick(event);
     }
   });
-
-  Sortable.create(container, {
-    animation: 150,
-  });
+  if(!sortableCreated){
+    Sortable.create(container, {
+      animation: 150,
+    });
+    window.sortableCreated = true;
+  }
   loadOrder();
 }
 function openPresets() {


### PR DESCRIPTION
The Sortable object for the buffer order was being created every single time the menu opened, which broke the dragging functionality on some browsers. This PR introduces a `sortableCreated` variable which is set to false by default, and is changed to true the first time the buffer swapping menu is opened. If the menu is opened again while the variable is set to true, no new Sortable object is created, solving the issue. 